### PR TITLE
Add NBA player name aliases for Odds API mapping

### DIFF
--- a/etl/odds_etl.py
+++ b/etl/odds_etl.py
@@ -1211,6 +1211,17 @@ _NAME_SUFFIXES = re.compile(
     re.IGNORECASE
 )
 
+# Maps Odds API player names to their canonical NBA player names.
+# Add entries here whenever a player's Odds API name doesn't match nba.players.
+_NBA_PLAYER_ALIASES = {
+    "Moe Wagner":          "Moritz Wagner",
+    "Herb Jones":          "Herbert Jones",
+    "Nicolas Claxton":     "Nic Claxton",
+    "Vincent Williams Jr": "Vince Williams Jr.",
+    "Ron Holland":         "Ronald Holland II",
+    "Carlton Carrington":  "Bub Carrington",
+}
+
 
 def _normalize_name(name):
     """
@@ -1272,7 +1283,8 @@ def run_mappings(sport, engine):
         pm_rows = []
         matched = unmatched = 0
         for oname in all_names:
-            norm  = _normalize_name(oname)
+            lookup_name = _NBA_PLAYER_ALIASES.get(oname, oname)
+            norm  = _normalize_name(lookup_name)
             pid   = norm_to_pid.get(norm)
             mname = norm_to_name.get(norm)
             if pid: matched += 1


### PR DESCRIPTION
## Summary
This change improves player name matching between the Odds API and NBA player database by introducing a configurable alias mapping system.

## Key Changes
- Added `_NBA_PLAYER_ALIASES` dictionary to map Odds API player names to their canonical NBA player names
- Populated initial aliases for 6 players with known name mismatches:
  - "Moe Wagner" → "Moritz Wagner"
  - "Herb Jones" → "Herbert Jones"
  - "Nicolas Claxton" → "Nic Claxton"
  - "Vincent Williams Jr" → "Vince Williams Jr."
  - "Ron Holland" → "Ronald Holland II"
  - "Carlton Carrington" → "Bub Carrington"
- Updated `run_mappings()` to use the alias lookup before normalizing player names

## Implementation Details
The alias mapping is applied as a preprocessing step before name normalization, allowing the system to handle cases where the Odds API uses different name formats than the official NBA player database. This provides a maintainable way to add future aliases without modifying the core normalization logic.

https://claude.ai/code/session_013j77V2xgQtXABfC7c1xzuS